### PR TITLE
Update organization readme with wiki links

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -7,6 +7,14 @@ SPDX-License-Identifier: CC0-1.0
 # Hello!
 ### Welcome to NOI's organization on GitHub where we develop Free Open Source Software.
 ![ODH](https://user-images.githubusercontent.com/101118017/196189014-58a1c382-5f2c-43a8-bb53-b46c3de731ba.png)
-## All you need to know
-Who is [NOI AG/S.p.a.](https://noi.bz.it/en)?<br>
+
+## Who are we?
+Who is [NOI AG/S.p.a.](https://noi.bz.it/en)?<br />
 What is the [Open Data Hub](https://opendatahub.com/)?
+
+## Where can I find more information?
+Our [wiki](https://github.com/noi-techpark/odh-docs/wiki) containing general information about our projects.<br />
+Our [guidelines for developers](https://github.com/noi-techpark/odh-docs/wiki/Guidelines-for-developers-and-licenses) containing information for everyone wanting to contribute.
+
+##
+We are [REUSE](https://reuse.software) compliant, find more information about reuse in our projects [here](https://github.com/noi-techpark/odh-docs/wiki/REUSE).


### PR DESCRIPTION
As discussed with @sseppi and @clezag here a proposal for a small addition to the organization level README to include the main links to the general documentation and a statement that we are REUSE compliant.
Would love some feedback also from @ohnewein  as even though the changes are small, it's the first thing somebody sees when opening the [NOI Techpark Github](https://github.com/noi-techpark)
Note: the linked wiki page containing more information about reuse in our projects is in progress.